### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/mod/student.py
+++ b/mod/student.py
@@ -424,7 +424,8 @@ class StudentTab(ctk.CTkFrame):
                     pywhatkit.sendwhatmsg_instantly(full_number, message)
                     print(f"Message envoyé avec succès à {full_number}.")
                 except Exception as e:
-                    print(f"Échec de l'envoi du message à {full_number} : {e}")
+                    masked_number = full_number[:3] + "****" + full_number[-2:]
+                    print(f"Échec de l'envoi du message à {masked_number} : {e}")
 
     
 class AddStudentForm(ctk.CTkFrame):


### PR DESCRIPTION
Potential fix for [https://github.com/iyehah/center-elaula/security/code-scanning/2](https://github.com/iyehah/center-elaula/security/code-scanning/2)

To fix the problem, we need to avoid logging sensitive information such as phone numbers. Instead of logging the full phone number, we can log a masked version of it or simply indicate that an error occurred without including the sensitive data. This way, we maintain the functionality of logging errors without exposing sensitive information.

We will modify the code in `mod/student.py` to mask the phone numbers before logging them. Specifically, we will update the logging statement on line 427 to mask the phone number.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
